### PR TITLE
h2 uri encoding

### DIFF
--- a/components/mdxComponents.tsx
+++ b/components/mdxComponents.tsx
@@ -9,17 +9,21 @@ export const MdxComponents = {
     </>
   ),
   h2: (props) => {
-    const uriChildren = encodeURI(props.children);
+    const h2Text = props.children;
+    const h2ReplaceSpecialCharsWithDash = h2Text
+      .toLowerCase()
+      .replace(/[^a-zA-Z0-9]+/g, "-");
+    const uri = encodeURI(h2ReplaceSpecialCharsWithDash);
     return (
       <>
-        <a id={uriChildren}></a>
+        <a id={uri}></a>
         <div className="flex items-center -ml-8 mt-12">
-          <a href={`#${uriChildren}`} className="no-underline w-8">
+          <a href={`#${uri}`} className="no-underline w-8">
             <span className="text-lg my-0">
               <LinkIcon />
             </span>
           </a>
-          <a href={`#${uriChildren}`} className="no-underline hover:underline">
+          <a href={`#${uri}`} className="no-underline hover:underline">
             <h2 {...props} className="my-0"></h2>
           </a>
         </div>

--- a/components/mdxComponents.tsx
+++ b/components/mdxComponents.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 export const MdxComponents = {
   h1: (props) => (
     <>
+      <a id="top"></a>
       <h1 {...props} className="text-3xl mb-2"></h1>
       <hr className="mt-0 mb-2 h-0.5 border-0" />
     </>


### PR DESCRIPTION
- for h2 anchor links use dashes in URIs
- for h1, add top anchor link above
